### PR TITLE
Handle special line when stream using ask-llm.go

### DIFF
--- a/ask-llm.go
+++ b/ask-llm.go
@@ -96,6 +96,15 @@ func chat(messages []Message, handler func(string)) (string, error) {
 		scanner := bufio.NewScanner(resp.Body)
 		for scanner.Scan() {
 			line := scanner.Text()
+			if len(line) == 0 {
+				continue
+			}
+			if line[0] == ':' {
+				continue
+			}
+			if line == "data: [DONE]" {
+				break
+			}
 			if strings.HasPrefix(line, "data: ") {
 				payload := line[6:]
 				var data struct {


### PR DESCRIPTION
Hi mas @ariya , hereby I'd like to make a little fixing on handling special line when stream using ask-llm.go. Please check whenever you have a moment, thanks!

---

Before
<img width="1351" alt="Screenshot 2024-12-15 at 16 16 12" src="https://github.com/user-attachments/assets/f09399db-18bd-48c4-af65-aa58cddffadc" />

After
<img width="1341" alt="Screenshot 2024-12-15 at 16 35 35" src="https://github.com/user-attachments/assets/7c491df4-94ae-46b4-85b4-0fb98515571a" />